### PR TITLE
docs: Fixed stale vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ components:
           Service: tgw-spoke
         expose_eks_sg: false
         tgw_hub_tenant_name: core
-        tgw_hub_environment_name: ue1
+        tgw_hub_stage_name: network
 
     tgw/spoke:
       metadata:
@@ -67,9 +67,9 @@ components:
           - account:
               tenant: core
               stage: network
-            # Set this value if the vpc component has a different name in this account
-            vpc_component_names:
-              - vpc-dev
+              # Set this value if the vpc component has a different name in this account
+              vpc_component_names:
+                - vpc-dev
           - account:
               tenant: core
               stage: auto
@@ -210,7 +210,7 @@ No outputs.
 > <summary><strong>Watch demo of using Atmos with Terraform</strong></summary>
 > <img src="https://github.com/cloudposse/atmos/blob/main/docs/demo.gif?raw=true"/><br/>
 > <i>Example of running <a href="https://atmos.tools"><code>atmos</code></a> to manage infrastructure from our <a href="https://atmos.tools/quick-start/">Quick Start</a> tutorial.</i>
-> </detalis>
+> </details>
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -29,7 +29,7 @@ description: |-
             Service: tgw-spoke
           expose_eks_sg: false
           tgw_hub_tenant_name: core
-          tgw_hub_environment_name: ue1
+          tgw_hub_stage_name: network
 
       tgw/spoke:
         metadata:
@@ -43,9 +43,9 @@ description: |-
             - account:
                 tenant: core
                 stage: network
-              # Set this value if the vpc component has a different name in this account
-              vpc_component_names:
-                - vpc-dev
+                # Set this value if the vpc component has a different name in this account
+                vpc_component_names:
+                  - vpc-dev
             - account:
                 tenant: core
                 stage: auto


### PR DESCRIPTION
## what
* removed tgw_hub_environment_name
* added tgw_hub_stage_name
* realigned vpc_component_names

## why
* tgw_hub_environment_name was removed because it doesn't exist in current version
* tgw_hub_stage_name was added to give more clarity
* vpc_component_names was misaligned

## references
* None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Updated examples to use tgw_hub_stage_name: network instead of tgw_hub_environment_name: ue1.
  * Synchronized parameter docs to reflect the renamed input and its usage in tgw/spoke defaults.
  * Clarified YAML structure by adjusting indentation of vpc_component_names under tgw/spoke defaults; values unchanged.
  * Removed a markdownlint-restore directive in the Outputs section (no functional impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->